### PR TITLE
Add "Open In" for a few Mastodon clients

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -221,32 +221,32 @@ async fn show_feed(Query(params): Query<ShowFeed>, Host(host): Host) -> Result<R
                     body.push_str("/authorize_interaction?uri=");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in your Mastodon host</a>");
-                },
+                }
                 "elk" => {
                     body.push_str("https://elk.zone/");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Elk</a>");
-                },
+                }
                 "elkcanary" => {
                     body.push_str("https://main.elk.zone/");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Elk</a>");
-                },
+                }
                 "phanpy" => {
                     body.push_str("https://phanpy.social/#/");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Phanpy</a>");
-                },
+                }
                 "phanpydev" => {
                     body.push_str("https://dev.phanpy.social/#/");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Phanpy</a>");
-                },
+                }
                 "trunks" => {
                     body.push_str("https://trunks.social/resolve?url=");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Trunks</a>");
-                },
+                }
                 "ivory" => {
                     body.push_str("ivory://acct/openURL?url=");
                     body.push_str(&bookmark.url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,26 +213,26 @@ async fn show_feed(Query(params): Query<ShowFeed>, Host(host): Host) -> Result<R
 
         let client = &params.client;
         if !client.is_empty() {
-            body.push_str(" - Open in <a href=\"");
+            body.push_str(" - <a href=\"");
             match client.as_str() {
                 "elk" => {
                     body.push_str("https://elk.zone/");
                     body.push_str(&bookmark.url);
-                    body.push_str("\">Elk</a>");
+                    body.push_str("\">Open in Elk</a>");
                 },
                 "phanpy" => {
                     body.push_str("https://phanpy.social/#/");
                     body.push_str(&bookmark.url);
-                    body.push_str("\">Phanpy</a>");
+                    body.push_str("\">Open in Phanpy</a>");
                 },
                 "ivory" => {
                     body.push_str("ivory://acct/openURL?url=");
                     body.push_str(&bookmark.url);
-                    body.push_str("\">Ivory</a>");
+                    body.push_str("\">Open in Ivory</a>");
                 }
                 _ => {
                     body.push_str(&bookmark.url);
-                    body.push_str("\">Unknown client :(</a>");
+                    body.push_str("\">Open original post - unknown client :(</a>");
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,35 @@ async fn show_feed(Query(params): Query<ShowFeed>, Host(host): Host) -> Result<R
         body.push_str("<content:encoded><![CDATA[");
         body.push_str("<p><a href=\"");
         body.push_str(&bookmark.url);
-        body.push_str("\">Original Mastodon Post</a></p>");
+        body.push_str("\">Original Mastodon Post</a>");
+
+        let client = &params.client;
+        if !client.is_empty() {
+            body.push_str(" - Open in <a href=\"");
+            match client.as_str() {
+                "elk" => {
+                    body.push_str("https://elk.zone/");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Elk</a>");
+                },
+                "phanpy" => {
+                    body.push_str("https://phanpy.social/#/");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Phanpy</a>");
+                },
+                "ivory" => {
+                    body.push_str("ivory://acct/openURL?url=");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Ivory</a>");
+                }
+                _ => {
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Unknown client :(</a>");
+                }
+            }
+        }
+
+        body.push_str("</p>");
         body.push_str(&escape_for_cdata(&bookmark.content));
         body.push_str("]]></content:encoded>");
         body.push_str("</item>\n");
@@ -235,6 +263,8 @@ fn escape_for_cdata(input: &str) -> String {
 struct ShowFeed {
     host: String,
     token: String,
+    #[serde(default)]
+    client: String,
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,8 +215,20 @@ async fn show_feed(Query(params): Query<ShowFeed>, Host(host): Host) -> Result<R
         if !client.is_empty() {
             body.push_str(" - <a href=\"");
             match client.as_str() {
+                "host" => {
+                    body.push_str("https://");
+                    body.push_str(&params.host);
+                    body.push_str("/authorize_interaction?uri=");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Open in your Mastodon host</a>");
+                },
                 "elk" => {
                     body.push_str("https://elk.zone/");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Open in Elk</a>");
+                },
+                "elkcanary" => {
+                    body.push_str("https://main.elk.zone/");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Elk</a>");
                 },
@@ -224,6 +236,16 @@ async fn show_feed(Query(params): Query<ShowFeed>, Host(host): Host) -> Result<R
                     body.push_str("https://phanpy.social/#/");
                     body.push_str(&bookmark.url);
                     body.push_str("\">Open in Phanpy</a>");
+                },
+                "phanpydev" => {
+                    body.push_str("https://dev.phanpy.social/#/");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Open in Phanpy</a>");
+                },
+                "trunks" => {
+                    body.push_str("https://trunks.social/resolve?url=");
+                    body.push_str(&bookmark.url);
+                    body.push_str("\">Open in Trunks</a>");
                 },
                 "ivory" => {
                     body.push_str("ivory://acct/openURL?url=");

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -2,9 +2,18 @@
   export let launchLogin;
   export let feedUrlPromise;
 
+  let baseFeedUrl;
+
   function submitLoginForm(e) {
     launchLogin(e.target.host.value);
     e.preventDefault();
+  }
+
+  function changeClient(e) {
+    const client = e.target.value;
+    const result = document.querySelector('input');
+    if(!baseFeedUrl) baseFeedUrl = result.value;
+    result.value = `${client === 'none' ? baseFeedUrl : `${baseFeedUrl}&client=${client}`}`;
   }
 </script>
 
@@ -34,12 +43,26 @@
       />
     </form>
   {:else}
-    <div class="green">
-      Subscribe to the following URL in your feed reader. Anybody who knows this
-      URL can read your bookmarks!
+    <div>
+      <p class="green">Subscribe to the following URL in your feed reader. Anybody who knows this
+      URL can read your bookmarks!</p>
       <form class="pure-form">
         <fieldset>
           <input type="text" class="pure-input-1" readOnly value={feedUrl} />
+        </fieldset>
+        <fieldset>
+          <label>Optional: Add an "Open In" link to bookmarks
+            <select on:change={changeClient}>
+              <option value="none" selected>None</option>
+              <option value="host">Your Mastodon Host</option>
+              <option value="elk">Elk</option>
+              <option value="elkcanary">Elk Canary</option>
+              <option value="phanpy">Phanpy</option>
+              <option value="phanpydev">Phanpy Dev</option>
+              <option value="trunks">Trunks</option>
+              <option value="ivory">Ivory</option>
+            </select>
+          </label>
         </fieldset>
       </form>
     </div>

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -46,23 +46,20 @@
     <div>
       <p class="green">Subscribe to the following URL in your feed reader. Anybody who knows this
       URL can read your bookmarks!</p>
-      <form class="pure-form">
+      <form class="pure-form pure-form-stacked">
         <fieldset>
           <input type="text" class="pure-input-1" readOnly value={feedUrl} />
-        </fieldset>
-        <fieldset>
-          <label>Optional: Add an "Open In" link to bookmarks
-            <select on:change={changeClient}>
-              <option value="none" selected>None</option>
-              <option value="host">Your Mastodon Host</option>
-              <option value="elk">Elk</option>
-              <option value="elkcanary">Elk Canary</option>
-              <option value="phanpy">Phanpy</option>
-              <option value="phanpydev">Phanpy Dev</option>
-              <option value="trunks">Trunks</option>
-              <option value="ivory">Ivory</option>
-            </select>
-          </label>
+          <label for="form-client-link">Optional: Add an "Open In" link to bookmarks</label>
+          <select on:change={changeClient}>
+            <option value="none" selected>None</option>
+            <option value="host">Your Mastodon Host</option>
+            <option value="elk">Elk</option>
+            <option value="elkcanary">Elk Canary</option>
+            <option value="phanpy">Phanpy</option>
+            <option value="phanpydev">Phanpy Dev</option>
+            <option value="trunks">Trunks</option>
+            <option value="ivory">Ivory</option>
+          </select>
         </fieldset>
       </form>
     </div>


### PR DESCRIPTION
Hey! Thanks for building & hosting this, it's really improved my Mastodon usage.

This adds an `Open In` link for a couple of clients, in addition to the `Original Mastodon Post` link. I really like this in @tvler's [StreetPass](https://github.com/tvler/streetpass), so thought I'd add take a shot at adding it here. I'd add more clients, but Ivory seems to be the only one that has [a page on its scheme](https://tapbots.com/support/ivory/tips/urlschemes) and I don't have an iPhone to test.

I'd like to add a little dropdown on the results page to optionally add one of the known client query params.

![firefox_2024-05-01_23-31-59](https://github.com/untitaker/mastodon-bookmark-rss/assets/904055/f3ca2e8f-024c-4560-a14a-af989481f166)


This is the first time I've done anything in Rust, so hopefully it looks alright. I had some confusion between String and str.